### PR TITLE
Fix package names for SDL_mixer and SDL_sound

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,23 @@ cmake-build-debug
 cmake_install.cmake
 CMakeCache.txt
 Makefile
+
+# build results
+convertresource
+dumpads
+dumpbmx
+dumpbok
+dumpddx
+dumpfnt
+dumpgam
+dumplbl
+dumpobj
+dumppal
+dumpreq
+dumpscx
+dumpsnd
+dumptbl
+dumpttm
+dumpwld
+resourcedemo
+xbak

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.13)
 project(xbak)
 
 find_package(SDL REQUIRED)
-find_package(SDL_MIXER REQUIRED)
-find_package(SDL_SOUND REQUIRED)
+find_package(SDL_mixer REQUIRED)
+find_package(SDL_sound REQUIRED)
 
 include_directories(${SDL_INCLUDE_DIR})
 include_directories(${SDL_MIXER_INCLUDE_DIR})


### PR DESCRIPTION
Otherwise, the packages couldn't not be found (tested in Ubuntu 22.04)